### PR TITLE
added /1 to end url service so not broken

### DIFF
--- a/CaliberTrainerReport/src/app/url.service.ts
+++ b/CaliberTrainerReport/src/app/url.service.ts
@@ -9,6 +9,6 @@ export class UrlService {
   constructor(private http: HttpClient) { }
 
   getUrl(): string{
-    return 'http://localhost:8080/excaliber/';
+    return 'http://localhost:8080/excaliber/1/';
   }
 }


### PR DESCRIPTION
endpoints seem to currently need an id in the url, so this hard coded /1/ is to patch the charts being broken until some sort of id selection is implemented