### PR TITLE
add errorHandler and catchError pipe operator in some services

### DIFF
--- a/CaliberTrainerReport/src/app/services/BatchTechnicalStatusBySkillCategory.service.ts
+++ b/CaliberTrainerReport/src/app/services/BatchTechnicalStatusBySkillCategory.service.ts
@@ -2,23 +2,32 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { UrlService } from './url.service';
-import { map } from 'rxjs/operators';
-
+import { catchError, map } from 'rxjs/operators';
+import { ErrorHandlingServiceService } from './error-handling-service.service';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class BatchTechnicalStatusBySkillCategoryService {
   xlabels: string[]; // Push batches onto here
 
   yAvglabels: any[];
-  constructor(private http: HttpClient, private urlService: UrlService) { }
+  constructor(
+    private http: HttpClient,
+    private urlService: UrlService,
+    private errorHandler: ErrorHandlingServiceService
+  ) {}
 
-  getAvgCategoryScoresObservables(): Observable<any>{
+  getAvgCategoryScoresObservables(): Observable<any> {
     // this will be making our observable
-    return this.http.get(this.urlService.getUrlWithId() + 'BatchTechnicalStatusBySkillCategory/').pipe(
-      map(resp => resp)
-    );
+    return this.http
+      .get(
+        this.urlService.getUrlWithId() + 'BatchTechnicalStatusBySkillCategory/'
+      )
+      .pipe(
+        map((resp) => resp),
+        catchError(this.errorHandler.handleError)
+      );
   }
 
   // // X-axis variables...
@@ -35,7 +44,6 @@ export class BatchTechnicalStatusBySkillCategoryService {
 
   //   this.yAvglabels = [];
 
-
   //   if (category === 'SQL'){
   //   // our subscribe method eventually
   //     this.yAvglabels.push(0);
@@ -50,5 +58,4 @@ export class BatchTechnicalStatusBySkillCategoryService {
   //   }
   //   return this.yAvglabels;
   // }
-
 }

--- a/CaliberTrainerReport/src/app/services/TechnicalStatusByWeek.service.ts
+++ b/CaliberTrainerReport/src/app/services/TechnicalStatusByWeek.service.ts
@@ -2,18 +2,25 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { UrlService } from './url.service';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { catchError, map } from 'rxjs/operators';
+import { ErrorHandlingServiceService } from './error-handling-service.service';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class TechnicalStatusByWeekService {
-  constructor(private http: HttpClient, private urlService: UrlService) { }
+  constructor(
+    private http: HttpClient,
+    private urlService: UrlService,
+    private errorHandler: ErrorHandlingServiceService
+  ) {}
 
-  getTechnicalStatusByWeek(): Observable<any>{
-    return this.http.get(this.urlService.getUrlWithId() + 'TechnicalStatusByWeek').pipe(
-      map(resp => resp)
-    );
+  getTechnicalStatusByWeek(): Observable<any> {
+    return this.http
+      .get(this.urlService.getUrlWithId() + 'TechnicalStatusByWeek')
+      .pipe(
+        map((resp) => resp),
+        catchError(this.errorHandler.handleError)
+      );
   }
-
 }

--- a/CaliberTrainerReport/src/app/services/TechnicalStatusPerBatch.service.ts
+++ b/CaliberTrainerReport/src/app/services/TechnicalStatusPerBatch.service.ts
@@ -2,10 +2,11 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { UrlService } from './url.service';
-import { map } from 'rxjs/operators';
+import { catchError, map } from 'rxjs/operators';
+import { ErrorHandlingServiceService } from './error-handling-service.service';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 // localhost:8080/excaliber/JSONController
 // localhost:8080/excaliber/TechnicalStatusPerBatch
@@ -14,13 +15,20 @@ export class TechnicalStatusPerBatchService {
   yGoodlabels: any[];
   yOkaylabels: any[];
   yBadlabels: any[];
-  constructor(private http: HttpClient, private urlService: UrlService) { }
+  constructor(
+    private http: HttpClient,
+    private urlService: UrlService,
+    private errorHandler: ErrorHandlingServiceService
+  ) {}
 
   getTechnicalStatusPerBatch(): Observable<any> {
     // this.http.get(this.urlService.getUrl() + 'JSONController/');
-  
-    return this.http.get(this.urlService.getUrlWithId() + 'TechnicalStatusPerBatch/').pipe(
-      map( resp => resp )
-    );
+
+    return this.http
+      .get(this.urlService.getUrlWithId() + 'TechnicalStatusPerBatch/')
+      .pipe(
+        map((resp) => resp),
+        catchError(this.errorHandler.handleError)
+      );
   }
 }

--- a/CaliberTrainerReport/src/app/services/error-handling-service.service.spec.ts
+++ b/CaliberTrainerReport/src/app/services/error-handling-service.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ErrorHandlingServiceService } from './error-handling-service.service';
+
+describe('ErrorHandlingServiceService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: ErrorHandlingServiceService = TestBed.get(ErrorHandlingServiceService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/CaliberTrainerReport/src/app/services/error-handling-service.service.ts
+++ b/CaliberTrainerReport/src/app/services/error-handling-service.service.ts
@@ -1,0 +1,25 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { throwError } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ErrorHandlingServiceService {
+  constructor() {}
+
+  public handleError(error: HttpErrorResponse) {
+    if (error.error instanceof ErrorEvent) {
+      // A client-side or network error occurred. Handle it accordingly.
+      console.error('An error occurred:', error.error.message);
+    } else {
+      // The backend returned an unsuccessful response code.
+      // The response body may contain clues as to what went wrong.
+      console.error(
+        `Backend returned code ${error.status}, ` + `body was: ${error.error}`
+      );
+    }
+    // Return an observable with a user-facing error message.
+    return throwError('Something bad happened; please try again later.');
+  }
+}


### PR DESCRIPTION
This pull request would be an effort is contributing to global error handling on the frontend. I've added an errorHandlingService as a dependency injected into services that use http methods. This allows all http-related errors to be logged in detail, regardless of how the response is processed in the individual components. 